### PR TITLE
content-length can't be converted if None

### DIFF
--- a/eventkit_cloud/utils/overpass.py
+++ b/eventkit_cloud/utils/overpass.py
@@ -87,7 +87,7 @@ class Overpass(object):
             req = requests.post(self.url, data=q, stream=True)
             #Since the request takes a while, jump progress to an arbitrary 50 percent...
             self.progress_tracker(50)
-            size = int(req.headers.get('content-length')) or len(req.content)
+            size = req.headers.get('content-length') or len(req.content)
             inflated_size = size*2
             CHUNK = 1024 * 1024 * 5  # 5MB chunks
             with open(self.raw_osm, 'wb') as fd:


### PR DESCRIPTION
if content-length header is None exception is thrown.