### PR TITLE
don't blacklist .osm files, add period to extension for .om5

### DIFF
--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -25,7 +25,7 @@ from eventkit_cloud.utils import (
 )
 import socket
 
-BLACKLISTED_ZIP_EXTS = ['.pbf', '.osm', '.ini', '.txt', 'om5']
+BLACKLISTED_ZIP_EXTS = ['.pbf', '.ini', '.txt', '.om5']
 COMPLETE_STATES = ['COMPLETED', 'INCOMPLETE', 'CANCELED']
 
 # Get an instance of a logger
@@ -649,7 +649,7 @@ class ZipFileTask(Task):
 
         run_uid = str(run_uid)
         if settings.USE_S3:
-            # TODO open up a stream directly to the s3 file so no local 
+            # TODO open up a stream directly to the s3 file so no local
             #      persistence is required
             zipfile_url = s3.upload_to_s3(run_uid, zip_filename)
             os.remove(zip_filepath)
@@ -704,7 +704,7 @@ class FinalizeRunTask(Task):
             'Eventkit Team <eventkit.team@gmail.com>'
         )
         ctx = {'url': url, 'status': run.status}
-        
+
         text = get_template('email/email.txt').render(ctx)
         html = get_template('email/email.html').render(ctx)
         msg = EmailMultiAlternatives(subject, text, to=to, from_email=from_email)

--- a/eventkit_cloud/tasks/tests/test_export_tasks.py
+++ b/eventkit_cloud/tasks/tests/test_export_tasks.py
@@ -19,7 +19,7 @@ from eventkit_cloud.jobs import presets
 from eventkit_cloud.jobs.models import Job, Tag
 from eventkit_cloud.tasks.export_tasks import (
     ExportTaskErrorHandler, FinalizeRunTask,
-    GeneratePresetTask, KmlExportTask, OSMConfTask, 
+    GeneratePresetTask, KmlExportTask, OSMConfTask,
     ExternalRasterServiceExportTask, GeopackageExportTask,
     OSMPrepSchemaTask, OSMToPBFConvertTask, OverpassQueryTask,
     ShpExportTask, ArcGISFeatureServiceExportTask,
@@ -396,7 +396,7 @@ class TestExportTasks(ExportTaskBase):
         mock_os_walk.return_value = [(
             '/var/lib/eventkit/exports_staging/' + run_uid + '/osm-vector',
             None,
-            ['test.gpkg', 'test.osm']  # osm should get filtered out
+            ['test.gpkg', 'test.om5']  # om5 should get filtered out
         )]
         date = timezone.now().strftime('%Y%m%d')
         fname = 'test-osm-vector-%s.gpkg' % (date,)


### PR DESCRIPTION
tweaks to file extension blacklist for zip files ([11570](https://redmine.devops.geointservices.io/issues/11570))

.osm files were added to blacklist in initial zip files release.  we actually want these in exports.

.om5 files were missing a period (`.`) in the extension.
