### PR TITLE
added ability to prevent seeding if there is issue with URL.

### DIFF
--- a/eventkit_cloud/utils/external_service.py
+++ b/eventkit_cloud/utils/external_service.py
@@ -17,6 +17,7 @@ from django.core.files.temp import NamedTemporaryFile
 import logging
 from django.db import connections
 from ..tasks.task_process import TaskProcess
+import requests
 
 logger = logging.getLogger(__name__)
 
@@ -106,6 +107,7 @@ class ExternalRasterServiceToGeopackage(object):
         seed_configuration = SeedingConfiguration(seed_dict, mapproxy_conf=mapproxy_configuration)
         logger.info("Beginning seeding to {}".format(self.gpkgfile))
         try:
+            check_service(conf_dict)
             progress_logger = CustomLogger(verbose=True, task_uid=self.task_uid)
             task_process = TaskProcess(task_uid=self.task_uid)
             task_process.start_process(billiard=True, target=seeder.seed,
@@ -188,3 +190,22 @@ def create_conf_from_url(service_url):
     except yaml.YAMLError as exc:
         logger.error(exc)
     return conf_dict
+
+
+def check_service(conf_dict):
+    """
+    Used to verify the state of the service before running the seed task. This is used to prevent and invalid url from
+    being seeded.  MapProxy's default behavior is to either cache a blank tile or to retry, that behavior can be altered,
+    in the cache settings (i.e. `get_cache_template`).
+    :param conf_dict: A MapProxy configuration as a dict.
+    :return: None if valid, otherwise exception is raised.
+    """
+
+    for source in conf_dict.get('sources', []):
+        if not conf_dict['sources'][source].get('url'):
+            continue
+        tile = {'x': '1', 'y': '1', 'z': '1'}
+        url = conf_dict['sources'][source].get('url') % tile
+        response = requests.get(url, verify=False)
+        if response.status_code in [401, 403]:
+            raise Exception("The provider does not have valid credentials.")

--- a/eventkit_cloud/utils/external_service.py
+++ b/eventkit_cloud/utils/external_service.py
@@ -208,4 +208,8 @@ def check_service(conf_dict):
         url = conf_dict['sources'][source].get('url') % tile
         response = requests.get(url, verify=False)
         if response.status_code in [401, 403]:
+            logger.error("The provider has invalid credentials with status code {0} and the text: \n{1}".format(response.status_code, response.text))
             raise Exception("The provider does not have valid credentials.")
+        elif response.status_code >= 500:
+            logger.error("The provider reported a server error with status code {0} and the text: \n{1}".format(response.status_code, response.text))
+            raise Exception("The provider reported a server error.")

--- a/eventkit_cloud/utils/s3.py
+++ b/eventkit_cloud/utils/s3.py
@@ -65,7 +65,7 @@ def delete_from_s3(run_uid=None, download_url=None, client=None):
 
     if download_url:
         parts = download_url.split('/')
-        items = [{'Key':'/'.join([parts[-2], parts[-1]])}]
+        items = [{'Key': '/'.join([parts[-2], parts[-1]])}]
 
     for item in items:
         _key = item['Key']

--- a/eventkit_cloud/utils/tests/test_external_service.py
+++ b/eventkit_cloud/utils/tests/test_external_service.py
@@ -7,7 +7,7 @@ from mock import Mock, patch
 from django.core.files.temp import NamedTemporaryFile
 from django.conf import settings
 from django.test import TransactionTestCase
-from ..external_service import ExternalRasterServiceToGeopackage, create_conf_from_url
+from ..external_service import ExternalRasterServiceToGeopackage, create_conf_from_url, check_service
 from mapproxy.config.config import base_config
 from mapproxy.seed.config import SeedConfigurationError
 
@@ -18,11 +18,10 @@ class TestWMTSToGeopackage(TransactionTestCase):
     def setUp(self, ):
         self.path = settings.ABS_PATH()
 
-
     @patch('eventkit_cloud.utils.external_service.yaml')
     @patch('eventkit_cloud.utils.external_service.NamedTemporaryFile')
     @patch('eventkit_cloud.utils.external_service.config_command')
-    def test_create_conf_from_arcgis(self, config_command, temp, yaml):
+    def test_create_conf_from_arcgis(self, config_command, temp, yaml, check_service):
         test_file = NamedTemporaryFile()
         url = 'http://server.arcgisonline.com/arcgis/rest/services/ESRI_Imagery_World_2D/MapServer'
         test_yaml = "layer:\r\n  - name: imagery\r\n    title: imagery\r\n    sources: [cache]\r\n\r\nsources:\r\n  imagery_arcgis:\r\n    type: arcgis\r\n    grid: webmercator\r\n    req:\r\n      url: http://server.arcgisonline.com/arcgis/rest/services/ESRI_Imagery_World_2D/MapServer\r\n      layers: \r\n        show: 0\r\n\r\ngrids:\r\n  webmercator:\r\n    srs: EPSG:3857\r\n    tile_size: [256, 256]\r\n    origin: nw"
@@ -34,13 +33,14 @@ class TestWMTSToGeopackage(TransactionTestCase):
         config_command.assert_called_once_with(cmd)
         self.assertEqual(w2g, real_yaml.load(test_yaml))
 
+    @patch('eventkit_cloud.utils.external_service.check_service')
     @patch('eventkit_cloud.utils.external_service.SeedingConfiguration')
     @patch('eventkit_cloud.utils.external_service.seeder')
     @patch('eventkit_cloud.utils.external_service.Process')
     @patch('eventkit_cloud.utils.external_service.load_config')
     @patch('eventkit_cloud.utils.external_service.get_cache_template')
     @patch('eventkit_cloud.utils.external_service.get_seed_template')
-    def test_convert(self, seed_template, cache_template, load_config, process, seeder, seeding_config):
+    def test_convert(self, seed_template, cache_template, load_config, process, seeder, seeding_config, check_service):
         process.return_value = Mock()
         gpkgfile = '/var/lib/eventkit/test.gpkg'
         config = "layer:\r\n  - name: imagery\r\n    title: imagery\r\n    sources: [cache]\r\n\r\nsources:\r\n  imagery_arcgis:\r\n    type: arcgis\r\n    grid: webmercator\r\n    req:\r\n      url: http://server.arcgisonline.com/arcgis/rest/services/ESRI_Imagery_World_2D/MapServer\r\n      layers: \r\n        show: 0\r\n\r\ngrids:\r\n  webmercator:\r\n    srs: EPSG:3857\r\n    tile_size: [256, 256]\r\n    origin: nw"
@@ -69,6 +69,7 @@ class TestWMTSToGeopackage(TransactionTestCase):
 
         seed_dict = {'cache': {'sources': ['imagery_arcgis'], 'cache': {'type': 'geopackage', 'filename': '/var/lib/eventkit/test.gpkg'}, 'grids': ['webmercator']}}
         seed_template.assert_called_once_with(bbox=[-2, -2, 2, 2], level_from=0, level_to=10)
+        check_service.assert_called_once(json_config)
         process.assert_called_once()
 
 class TestWMTSToGeopackage(TransactionTestCase):
@@ -90,6 +91,7 @@ class TestWMTSToGeopackage(TransactionTestCase):
         config_command.assert_called_once_with(cmd)
         self.assertEqual(w2g, real_yaml.load(test_yaml))
 
+    @patch('eventkit_cloud.utils.external_service.check_service')
     @patch('eventkit_cloud.utils.external_service.remove_empty_zoom_levels')
     @patch('django.db.connections')
     @patch('eventkit_cloud.tasks.models.ExportTask')
@@ -98,7 +100,7 @@ class TestWMTSToGeopackage(TransactionTestCase):
     @patch('eventkit_cloud.utils.external_service.load_config')
     @patch('eventkit_cloud.utils.external_service.get_cache_template')
     @patch('eventkit_cloud.utils.external_service.get_seed_template')
-    def test_convert(self, seed_template, cache_template, load_config, seeder, seeding_config, export_task, connections, remove_zoom_levels):
+    def test_convert(self, seed_template, cache_template, load_config, seeder, seeding_config, export_task, connections, remove_zoom_levels, check_service):
         gpkgfile = '/var/lib/eventkit/test.gpkg'
         config = "layers:\r\n - name: imagery\r\n   title: imagery\r\n   sources: [cache]\r\n\r\nsources:\r\n  imagery_wmts:\r\n    type: tile\r\n    grid: webmercator\r\n    url: http://a.tile.openstreetmap.fr/hot/%(z)s/%(x)s/%(y)s.png\r\n\r\ngrids:\r\n  webmercator:\r\n    srs: EPSG:3857\r\n    tile_size: [256, 256]\r\n    origin: nw"
         json_config = real_yaml.load(config)
@@ -126,10 +128,12 @@ class TestWMTSToGeopackage(TransactionTestCase):
         json_config['sources']['imagery_wmts']['transparent'] = True
         json_config['sources']['imagery_wmts']['on_error'] = {'other': {'cache': False,'response': 'transparent'}}
 
+        check_service.assert_called_once(json_config)
         load_config.assert_called_once_with(mapproxy_base, config_dict=json_config)
         remove_zoom_levels.assert_called_once_with(gpkgfile)
         seed_template.assert_called_once_with(bbox=[-2, -2, 2, 2], level_from=0, level_to=10)
 
+    @patch('eventkit_cloud.utils.external_service.check_service')
     @patch('eventkit_cloud.utils.external_service.remove_empty_zoom_levels')
     @patch('django.db.connections')
     @patch('mapproxy.seed.spec.validate_seed_conf')
@@ -141,7 +145,7 @@ class TestWMTSToGeopackage(TransactionTestCase):
     @patch('eventkit_cloud.utils.external_service.load_config')
     @patch('eventkit_cloud.utils.external_service.get_cache_template')
     @patch('eventkit_cloud.utils.external_service.get_seed_template')
-    def test_convert_failure(self, seed_template, cache_template, load_config, seeder, seeding_config, task_process, export_task, validate_options, validate_seed_conf, connections, remove_zoom_levels):
+    def test_convert_failure(self, seed_template, cache_template, load_config, seeder, seeding_config, task_process, export_task, validate_options, validate_seed_conf, connections, remove_zoom_levels, check_service):
         gpkgfile = '/var/lib/eventkit/test.gpkg'
         config = "layers:\r\n - name: imagery\r\n   title: imagery\r\n   sources: [cache]\r\n\r\nsources:\r\n  imagery_wmts:\r\n    type: tile\r\n    grid: webmercator\r\n    url: http://a.tile.openstreetmap.fr/hot/%(z)s/%(x)s/%(y)s.png\r\n\r\ngrids:\r\n  webmercator:\r\n    srs: EPSG:3857\r\n    tile_size: [256, 256]\r\n    origin: nw"
         json_config = real_yaml.load(config)
@@ -183,4 +187,22 @@ class TestWMTSToGeopackage(TransactionTestCase):
         self.assertRaises(SeedConfigurationError)
         connections.close_all.assert_called_once()
         remove_zoom_levels.assert_called_once_with(gpkgfile)
+        check_service.assert_called_once(json_config)
         seed_template.assert_called_once_with(bbox=[-2, -2, 2, 2], level_from=0, level_to=10)
+
+
+class TestHelpers(TransactionTestCase):
+
+    @patch('requests.get')
+    def test_check_service(self, requests_get):
+
+        conf_dict = {'sources': {'source1': {'url': 'http://example.com/url'},
+                                 'source2': {'url': 'http://example2.com/url'}}}
+
+        requests_get.return_value = Mock(status_code=200)
+        self.assertIsNone(check_service(conf_dict))
+
+        response = Mock()
+        response.status_code.return_value = [200, 401]
+        self.assertRaisesMessage(Exception, "The provider does not have valid credentials.", check_service(conf_dict))
+

--- a/manage.py
+++ b/manage.py
@@ -1,19 +1,20 @@
 #!/usr/bin/env python
 import os
-import sys
 import subprocess
 from django.conf import settings
-
+import sys
+import logging
 
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "eventkit_cloud.settings.prod")
 
     from django.core.management import execute_from_command_line
 
-    if os.getenv("COVERAGE"):
-        is_testing = 'test' in sys.argv
+    if 'test' in sys.argv:
 
-        if is_testing:
+        logging.disable(logging.CRITICAL)
+
+        if os.getenv("COVERAGE"):
             import coverage
 
             cov = coverage.coverage(config_file=".coveragerc",
@@ -23,15 +24,17 @@ if __name__ == "__main__":
 
         execute_from_command_line(sys.argv)
 
-        if is_testing:
+        if os.getenv("COVERAGE"):
             cov.stop()
             cov.save()
             cov.report()
             cov.html_report(directory='./coverage')
 
-            if os.getenv("TRAVIS"):
-                coveralls = os.path.join(os.path.dirname(os.path.dirname(getattr(settings, "BASE_DIR", '/var/lib/eventkit'))), '.virtualenvs/eventkit/bin/coveralls')
-                subprocess.call([coveralls])
+        if os.getenv("TRAVIS"):
+            coveralls = os.path.join(os.path.dirname(os.path.dirname(getattr(settings, "BASE_DIR", '/var/lib/eventkit'))), '.virtualenvs/eventkit/bin/coveralls')
+            subprocess.call([coveralls])
+
+        logging.disable(logging.NOTSET)
 
     else:
         execute_from_command_line(sys.argv)


### PR DESCRIPTION
The url is checked prior to seeding. 

This doesn't resolve the problem if the service is blocked mid seed.  However follow on requests will receive a useful error message.