### PR TITLE
16551 - created a view for geonames api

### DIFF
--- a/eventkit_cloud/settings/project.py
+++ b/eventkit_cloud/settings/project.py
@@ -56,6 +56,7 @@ GARMIN_CONFIG = os.getenv('GARMIN_CONFIG', '/var/lib/eventkit/conf/garmin_config
 # url to overpass api endpoint
 # OVERPASS_API_URL = 'http://cloud.eventkit.dev/overpass-api/interpreter'
 OVERPASS_API_URL = os.getenv('OVERPASS_API_URL', 'http://overpass-api.de/api/interpreter')
+GEONAMES_API_URL = os.getenv('GEONAMES_API_URL', 'http://api.geonames.org/searchJSON')
 
 """
 Maximum extent of a Job

--- a/eventkit_cloud/ui/static/ui/js/config.js
+++ b/eventkit_cloud/ui/static/ui/js/config.js
@@ -30,7 +30,7 @@ Config.NOMINATIM_SEARCH_URL = 'http://nominatim.openstreetmap.org/search';
 Config.MAPQUEST_SEARCH_URL = 'http://open.mapquestapi.com/nominatim/v1/search';
 
 // geonames
-Config.GEONAMES_SEARCH_URL = 'http://api.geonames.org/searchJSON';
+Config.GEONAMES_SEARCH_URL = '/exports/request_geonames';
 
 // error pages
 Config.CREATE_ERROR_URL = '/error';

--- a/eventkit_cloud/ui/static/ui/js/create.js
+++ b/eventkit_cloud/ui/static/ui/js/create.js
@@ -1977,9 +1977,6 @@ create.job = (function(){
                         Config.GEONAMES_SEARCH_URL,
                         {
                             q: query,
-                            maxRows: 20,
-                            username: 'hotexports',
-                            style: 'full'
                         },
                         function(data){
                             // build list of suggestions

--- a/eventkit_cloud/ui/tests/test_views.py
+++ b/eventkit_cloud/ui/tests/test_views.py
@@ -28,7 +28,7 @@ class TestUIViews(TestCase):
 
 
     @patch('eventkit_cloud.ui.views.requests')
-    def test_data_estimate_view(self, requests):
+    def test_request_geonames_view(self, requests):
         expected_return = {"some": "json"}
         response = Mock()
         response.json.return_value = expected_return

--- a/eventkit_cloud/ui/tests/test_views.py
+++ b/eventkit_cloud/ui/tests/test_views.py
@@ -8,7 +8,7 @@ from mock import Mock, patch
 logger = logging.getLogger(__name__)
 
 
-class TestDataEstimationView(TestCase):
+class TestUIViews(TestCase):
 
     @patch('eventkit_cloud.ui.views.get_size_estimate')
     def test_data_estimate_view(self, get_estimate):
@@ -25,3 +25,28 @@ class TestDataEstimationView(TestCase):
         response = c.post('/en/exports/estimator', data=json.dumps({}), content_type='application/json')
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.content, 'Providers or BBOX were not supplied in the request')
+
+
+    @patch('eventkit_cloud.ui.views.requests')
+    def test_data_estimate_view(self, requests):
+        expected_return = {"some": "json"}
+        response = Mock()
+        response.json.return_value = expected_return
+        requests.get.return_value = response
+
+        c = Client()
+
+        with self.settings(GEONAMES_API_URL='http://api.geonames.org/something'):
+            response = c.get('/en/exports/request_geonames',
+                              data={'q': 'test'},
+                              content_type='application/json')
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(json.loads(response.content), expected_return)
+
+        with self.settings(GEONAMES_API_URL=None):
+            expected_return = {'error': 'A url was not provided for geonames'}
+            response = c.get('/en/exports/request_geonames',
+                             data={'q': 'test'},
+                             content_type='application/json')
+            self.assertEqual(response.status_code, 500)
+            self.assertEqual(json.loads(response.content), expected_return)

--- a/eventkit_cloud/ui/urls.py
+++ b/eventkit_cloud/ui/urls.py
@@ -3,7 +3,7 @@ from django.conf.urls import url
 from django.contrib.auth.decorators import login_required
 from django.views.generic import TemplateView
 
-from .views import clone_export, create_export, view_export, data_estimator
+from .views import clone_export, create_export, view_export, data_estimator, request_geonames
 
 urlpatterns = [
     url(r'^$', login_required(TemplateView.as_view(template_name='ui/list.html')), name='list'),
@@ -12,5 +12,6 @@ urlpatterns = [
         name='configurations'),
     url(r'^(?P<uuid>[^/]+)/$', login_required(view_export), name='detail'),
     url(r'^clone/(?P<uuid>[^/]+)/$', login_required(clone_export), name='clone'),
-    url(r'^estimator$', data_estimator)
+    url(r'^estimator$', data_estimator),
+    url(r'^request_geonames$', request_geonames)
 ]


### PR DESCRIPTION
HTTPS to HTTP errors occur when making requests to geonames, causing errors in the users browser.  This PR allows the API URL to be updated via the settings, and proxies the request through a view making sure that the response from the remote server is valid json.