### PR TITLE
fixed levels

### DIFF
--- a/eventkit_cloud/ui/data_estimator.py
+++ b/eventkit_cloud/ui/data_estimator.py
@@ -17,7 +17,7 @@ def get_size_estimate(provider, bbox, srs='3857'):
         provider = ExportProvider.objects.get(name=provider)
     except ObjectDoesNotExist:
         return None
-    levels = range(provider.level_from, provider.level_to+1)
+    levels = range(provider.level_from, provider.level_to)
     req_srs = mapproxy_srs.SRS(srs)
     bbox = mapproxy_grid.grid_bbox(bbox, mapproxy_srs.SRS(4326), req_srs)
 
@@ -39,6 +39,6 @@ def get_size_estimate(provider, bbox, srs='3857'):
 
 def get_gb_estimate(total_tiles, tile_width=256, tile_height=256):
     # the literal number there is the average pixels/GB ratio for tiles.
-    gigs_per_pixel_constant = 0.0000000005
+    gigs_per_pixel_constant = 0.0000000006
     return total_tiles*tile_width*tile_height*gigs_per_pixel_constant
 


### PR DESCRIPTION
There was a bug in the levels which would cause items with level 20 to produce an index out of bounds error in mapproxy.