### PR TITLE
Fix estimator

### DIFF
--- a/eventkit_cloud/ui/data_estimator.py
+++ b/eventkit_cloud/ui/data_estimator.py
@@ -17,7 +17,7 @@ def get_size_estimate(provider, bbox, srs='3857'):
         provider = ExportProvider.objects.get(name=provider)
     except ObjectDoesNotExist:
         return None
-    levels = range(provider.level_from, provider.level_to+1)
+    levels = range(provider.level_from, provider.level_to)
     req_srs = mapproxy_srs.SRS(srs)
     bbox = mapproxy_grid.grid_bbox(bbox, mapproxy_srs.SRS(4326), req_srs)
 
@@ -39,6 +39,6 @@ def get_size_estimate(provider, bbox, srs='3857'):
 
 def get_gb_estimate(total_tiles, tile_width=256, tile_height=256):
     # the literal number there is the average pixels/GB ratio for tiles.
-    gigs_per_pixel_constant = 0.0000000005
+    gigs_per_pixel_constant = 0.0000000006
     return total_tiles*tile_width*tile_height*gigs_per_pixel_constant
 

--- a/eventkit_cloud/ui/data_estimator.py
+++ b/eventkit_cloud/ui/data_estimator.py
@@ -17,12 +17,12 @@ def get_size_estimate(provider, bbox, srs='3857'):
         provider = ExportProvider.objects.get(name=provider)
     except ObjectDoesNotExist:
         return None
-    levels = range(provider.level_from, provider.level_to)
+    levels = range(provider.level_from, provider.level_to+1)
     req_srs = mapproxy_srs.SRS(srs)
     bbox = mapproxy_grid.grid_bbox(bbox, mapproxy_srs.SRS(4326), req_srs)
 
     tile_size = (256, 256)
-    tile_grid = mapproxy_grid.tile_grid_for_epsg(srs, tile_size=tile_size)
+    tile_grid = mapproxy_grid.TileGrid(srs, tile_size=tile_size, levels=len(levels))
     total_tiles = 0
     tiles = []
     for level in levels:

--- a/eventkit_cloud/ui/tests/test_data_estimator.py
+++ b/eventkit_cloud/ui/tests/test_data_estimator.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 class TestDataEstimation(TestCase):
 
     def test_get_gb_estimate(self):
-        expected_return_value = 0.000131072
+        expected_return_value = 0.0001572864
         actual_return_value = get_gb_estimate(4)
         self.assertAlmostEqual(expected_return_value, actual_return_value, places=9)
 


### PR DESCRIPTION
There was an issue where mapproxy tile grid was defaulting to 20 causing services with 21 levels to fail.