### PR TITLE
Moved postgis volume from a host mapping to a docker volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,7 +73,7 @@ services:
       - "5432"
     # This is stored up a directory because there will be permissions issues if ran with Vagrant shared directory.
     volumes:
-      - "../eventkit_database/database:/var/lib/postgresql/data"
+            - "postgis_database:/var/lib/postgresql/data"
   rabbitmq:
        image: rabbitmq:3.6.6-management
        expose:
@@ -111,4 +111,5 @@ services:
        environment:
          - BROKER_API=http://guest:guest@rabbitmq:15672/api/
          - BROKER_URL=amqp://guest:guest@rabbitmq:5672/
-
+volumes:
+    postgis_database:


### PR DESCRIPTION
On windows machines the postgis host mapping doesn't work correctly because of permissions.  The same desired action of persisting the volume through docker-compose down seems to be achieved through the use of a docker volume.