### PR TITLE
18537 login page drawer

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/Application.js
+++ b/eventkit_cloud/ui/static/ui/app/components/Application.js
@@ -43,7 +43,7 @@ export class Application extends Component {
     }
 
     componentWillMount() {
-        if (window.innerWidth <= 991){
+        if (window.innerWidth <= 991 || this.props.location.pathname == '/login/'){
             this.props.closeDrawer();
         }
     }
@@ -69,7 +69,7 @@ export class Application extends Component {
 
     render() {
 
-        const contentStyle = {  transition: 'margin-left 450ms cubic-bezier(0.23, 1, 0.32, 1)' };
+        const contentStyle = {transition: 'margin-left 450ms cubic-bezier(0.23, 1, 0.32, 1)'};
 
         if (this.props.drawerOpen) {
             contentStyle.marginLeft = 200;
@@ -108,7 +108,7 @@ export class Application extends Component {
 
         return (
             <MuiThemeProvider muiTheme={muiTheme}>
-                <div className={styles.root}>
+                <div>
                     <ClassificationBanner />
                     <header className="header" style={{height: '95px'}}>
                         <AppBar style={styles.appBar} title={img} onLeftIconButtonTouchTap={this.handleToggle.bind(this)} />
@@ -161,7 +161,7 @@ export class Application extends Component {
                         </MenuItem>
                     </Drawer>
                     <div style={contentStyle} className={css.contentStyle}>
-                    {this.props.children}
+                        {this.props.children}
                     </div>
                 </div>
             </MuiThemeProvider>

--- a/eventkit_cloud/ui/static/ui/app/components/Application.js
+++ b/eventkit_cloud/ui/static/ui/app/components/Application.js
@@ -34,19 +34,20 @@ const muiTheme = getMuiTheme({
 export class Application extends Component {
     constructor(props) {
         super(props);
-        this.state = {open: true}
-        this.state.drawerOpen = true
-
         this.handleToggle = this.handleToggle.bind(this)
         this.handleClose = this.handleClose.bind(this)
         this.onMenuItemClick = this.onMenuItemClick.bind(this);
+        this.onLogoutClick = this.onLogoutClick.bind(this);
     }
 
-    componentWillMount() {
-        if (window.innerWidth <= 991 || this.props.location.pathname == '/login/'){
-            this.props.closeDrawer();
-        }
-    }
+    componentWillReceiveProps(nextProps) {
+        // if the user is logged in and the screen is large the drawer should be open
+         if(nextProps.userData != this.props.userData) {
+             if(nextProps.userData != null && window.innerWidth > 991) {
+                 this.props.openDrawer();
+             }
+         }
+    } 
 
     handleToggle() {
         if(this.props.drawerOpen) {
@@ -65,6 +66,10 @@ export class Application extends Component {
         if(window.innerWidth <= 991) {
             this.handleToggle();
         }
+    }
+
+    onLogoutClick() {
+        this.props.closeDrawer();
     }
 
     render() {
@@ -108,7 +113,7 @@ export class Application extends Component {
 
         return (
             <MuiThemeProvider muiTheme={muiTheme}>
-                <div>
+                <div style={{backgroundColor: '#000'}}>
                     <ClassificationBanner />
                     <header className="header" style={{height: '95px'}}>
                         <AppBar style={styles.appBar} title={img} onLeftIconButtonTouchTap={this.handleToggle.bind(this)} />
@@ -118,7 +123,7 @@ export class Application extends Component {
                             overlayStyle={styles.drawer}
                             docked={true}
                             open={this.props.drawerOpen}
-                            onRequestChange={(open) => this.setState({open})}>
+                    >
                         <Subheader inset={false}>
                             <span style={{width:'100%'}}>
                                 <div style={styles.mainMenu}>MAIN MENU</div>
@@ -129,31 +134,31 @@ export class Application extends Component {
                                 </div>
                             </span>
                         </Subheader>
-                        <MenuItem className={css.menuItem} >
+                        <MenuItem className={css.menuItem} onClick={this.onMenuItemClick}>
                             <IndexLink className={css.link} activeClassName={css.active} onlyActiveOnIndex={true} to="/exports">
                                 <AVLibraryBooks style={{height: '22px', width: '22px'}}/>
                                 &nbsp;&nbsp;&nbsp;DataPack Library
                             </IndexLink>
                         </MenuItem>
-                        <MenuItem className={css.menuItem} >
+                        <MenuItem className={css.menuItem} onClick={this.onMenuItemClick}>
                             <Link className={css.link} activeClassName={css.active} to="/create" >
                                 <ContentAddBox style={{height: '22px', width: '22px'}}/>
                                 &nbsp;&nbsp;&nbsp;Create Datapack
                             </Link>
                         </MenuItem>
-                        <MenuItem className={css.menuItem} >
+                        <MenuItem className={css.menuItem} onClick={this.onMenuItemClick}>
                             <Link className={css.link} activeClassName={css.active} to="/about" >
                                 <ActionInfoOutline style={{height: '22px', width: '22px'}}/>
                                 &nbsp;&nbsp;&nbsp;About EventKit
                             </Link>
                         </MenuItem>
-                        <MenuItem className={css.menuItem} >
+                        <MenuItem className={css.menuItem} onClick={this.onMenuItemClick}>
                             <Link className={css.link} activeClassName={css.active} to="/account" >
                                 <SocialPerson style={{height: '22px', width: '22px'}}/>
                                 &nbsp;&nbsp;&nbsp;Account Settings
                             </Link>
                         </MenuItem>
-                        <MenuItem className={css.menuItem} >
+                        <MenuItem className={css.menuItem} onClick={this.onLogoutClick}>
                             <Link className={css.link} activeClassName={css.active} to="/logout" >
                                 <ActionExitToApp style={{height: '22px', width: '22px'}}/>
                                 &nbsp;&nbsp;&nbsp;Log Out
@@ -172,11 +177,15 @@ Application.propTypes = {
     children: PropTypes.object,
     openDrawer: PropTypes.func,
     closeDrawer: PropTypes.func,
+    userDate: PropTypes.object,
+    drawerOpen: PropTypes.bool,
 };
 
 function mapStateToProps(state) {
     return {
         drawerOpen: state.drawerOpen,
+        userData: state.user.data,
+
     }
 }
 

--- a/eventkit_cloud/ui/static/ui/app/components/DataPackPage/DataPackPage.js
+++ b/eventkit_cloud/ui/static/ui/app/components/DataPackPage/DataPackPage.js
@@ -244,7 +244,7 @@ export class DataPackPage extends React.Component {
         };
 
         return (
-            <div>
+            <div style={{backgroundImage: "url('./images/ek_topo_pattern.png')"}}>
                 <AppBar 
                     className={primaryStyles.sectionTitle} 
                     style={styles.appBar} title={pageTitle}
@@ -334,7 +334,7 @@ function mapDispatchToProps(dispatch) {
         },
         deleteRuns: (uid) => {
             dispatch(deleteRuns(uid));
-        }
+        },
     }
 }
 

--- a/eventkit_cloud/ui/static/ui/app/containers/loginContainer.js
+++ b/eventkit_cloud/ui/static/ui/app/containers/loginContainer.js
@@ -8,7 +8,6 @@ import {
 } from 'redux-form-material-ui'
 import styles from '../components/auth/Login.css'
 import {login} from '../actions/userActions'
-import {closeDrawer} from '../actions/exportsActions';
 import baseTheme from 'material-ui/styles/baseThemes/lightBaseTheme'
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
 import '../components/tap_events';

--- a/eventkit_cloud/ui/static/ui/app/containers/loginContainer.js
+++ b/eventkit_cloud/ui/static/ui/app/containers/loginContainer.js
@@ -8,6 +8,7 @@ import {
 } from 'redux-form-material-ui'
 import styles from '../components/auth/Login.css'
 import {login} from '../actions/userActions'
+import {closeDrawer} from '../actions/exportsActions';
 import baseTheme from 'material-ui/styles/baseThemes/lightBaseTheme'
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
 import '../components/tap_events';

--- a/eventkit_cloud/ui/static/ui/app/reducers/initialState.js
+++ b/eventkit_cloud/ui/static/ui/app/reducers/initialState.js
@@ -38,7 +38,7 @@ export default {
         import: "DEFAULT",
         search: "DEFAULT",
     },
-    drawerOpen: true,
+    drawerOpen: false,
     runsList: {
         fetching: false,
         fetched: false,

--- a/eventkit_cloud/ui/static/ui/app/tests/exportsReducer.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/exportsReducer.spec.js
@@ -112,7 +112,7 @@ describe('exportInfo reducer', () => {
 
 describe('drawerMenu Reducer', () => {
     it('should return initial state', () => {
-        expect(reducers.drawerMenuReducer(undefined, {})).toEqual(true);
+        expect(reducers.drawerMenuReducer(undefined, {})).toEqual(false);
     });
 
     it('should handle OPEN_DRAWER', () => {

--- a/eventkit_cloud/ui/static/ui/index.html
+++ b/eventkit_cloud/ui/static/ui/index.html
@@ -53,7 +53,7 @@
   </head>
   <body>
 
-    <div id='root'></div>
+    <div id='root' style="background-color: black;"></div>
 
     <script src="build/bundle.js"></script>
 

--- a/eventkit_cloud/ui/static/ui/index.html
+++ b/eventkit_cloud/ui/static/ui/index.html
@@ -11,9 +11,8 @@
 
     <style>
       body {
-        background-image: url('./images/ek_topo_pattern.png');
-        min-width: 360px;
         overflow: hidden;
+        min-width: 380px;
       }
 
       ::-webkit-scrollbar { 
@@ -23,6 +22,7 @@
       .ol-scale-line {
         background: rgba(0,0,0,0);
       }
+
       .ol-attribution.ol-uncollapsible {
         bottom: 10px;
         left: 10px;
@@ -53,7 +53,7 @@
   </head>
   <body>
 
-    <div id='root' style="background-color: black;"></div>
+    <div id='root'></div>
 
     <script src="build/bundle.js"></script>
 

--- a/eventkit_cloud/ui/templates/ui/index.html
+++ b/eventkit_cloud/ui/templates/ui/index.html
@@ -12,7 +12,6 @@
 
     <style>
       body {
-        background-image: url('./images/ek_topo_pattern.png');
         min-width: 360px;
         overflow: hidden;
       }


### PR DESCRIPTION
This PR will keep the drawer menu closed by default when user is on the login page. Once the user logs in, if the screen size is greater than 991px, the drawer will open. When the user logs out and gets directed back to the login page the drawer will close itself if open. Also contains a fix that should allow the background image to be properly displayed in the production environment.