### PR TITLE
19921 bug add zoom levels

### DIFF
--- a/eventkit_cloud/utils/external_service.py
+++ b/eventkit_cloud/utils/external_service.py
@@ -17,6 +17,7 @@ from django.core.files.temp import NamedTemporaryFile
 import logging
 from django.db import connections
 import requests
+import sqlite3
 
 logger = logging.getLogger(__name__)
 
@@ -138,6 +139,7 @@ class ExternalRasterServiceToGeopackage(object):
                                        kwargs={"tasks": seed_configuration.seeds(['seed']),
                                                "concurrency": int(getattr(settings, 'MAPPROXY_CONCURRENCY', 1)),
                                                "progress_logger": progress_logger})
+            check_zoom_levels(self.gpkgfile, mapproxy_configuration)
             remove_empty_zoom_levels(self.gpkgfile)
         except Exception as e:
             logger.error("Export failed for url {}.".format(self.service_url))
@@ -251,3 +253,27 @@ def check_service(conf_dict):
 
 def isclose(a, b, rel_tol=1e-09, abs_tol=0.0):
     return abs(a - b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)
+
+
+def check_zoom_levels(gpkg, mapproxy_configuration):
+    from .geopackage import (get_tile_table_names, get_zoom_levels_table, get_table_tile_matrix_information)
+
+    try:
+        grid = mapproxy_configuration.caches.get('cache').conf.get('grids')[0]
+        tile_size = mapproxy_configuration.grids.get(grid).conf.get('tile_size')
+        tile_grid = mapproxy_configuration.grids.get(grid).tile_grid()
+        for table_name in get_tile_table_names(gpkg):
+            actual_zoom_levels = get_zoom_levels_table(gpkg, table_name)
+            gpkg_tile_matrix = get_table_tile_matrix_information(gpkg, table_name)
+            for actual_zoom_level in actual_zoom_levels:
+                if actual_zoom_level not in [level.get('zoom_level') for level in gpkg_tile_matrix]:
+                    res = tile_grid.resolution(actual_zoom_level)
+                    grid_sizes = tile_grid.grid_sizes[actual_zoom_level]
+                    with sqlite3.connect(gpkg) as conn:
+                        conn.execute("""INSERT OR REPLACE INTO gpkg_tile_matrix
+                                                  (table_name, zoom_level, matrix_width, matrix_height, tile_width, tile_height, pixel_x_size, pixel_y_size)
+                                                  VALUES(?, ?, ?, ?, ?, ?, ?, ?)
+                                                  """,
+                                   (table_name, actual_zoom_level, grid_sizes[0], grid_sizes[1], tile_size[0], tile_size[1], res, res))
+    except Exception as e:
+        print(e)

--- a/eventkit_cloud/utils/external_service.py
+++ b/eventkit_cloud/utils/external_service.py
@@ -18,6 +18,7 @@ import logging
 from django.db import connections
 import requests
 import sqlite3
+from .geopackage import (get_tile_table_names, get_zoom_levels_table, get_table_tile_matrix_information)
 
 logger = logging.getLogger(__name__)
 
@@ -256,7 +257,6 @@ def isclose(a, b, rel_tol=1e-09, abs_tol=0.0):
 
 
 def check_zoom_levels(gpkg, mapproxy_configuration):
-    from .geopackage import (get_tile_table_names, get_zoom_levels_table, get_table_tile_matrix_information)
 
     try:
         grid = mapproxy_configuration.caches.get('cache').conf.get('grids')[0]
@@ -270,10 +270,8 @@ def check_zoom_levels(gpkg, mapproxy_configuration):
                     res = tile_grid.resolution(actual_zoom_level)
                     grid_sizes = tile_grid.grid_sizes[actual_zoom_level]
                     with sqlite3.connect(gpkg) as conn:
-                        conn.execute("""INSERT OR REPLACE INTO gpkg_tile_matrix
-                                                  (table_name, zoom_level, matrix_width, matrix_height, tile_width, tile_height, pixel_x_size, pixel_y_size)
-                                                  VALUES(?, ?, ?, ?, ?, ?, ?, ?)
-                                                  """,
-                                   (table_name, actual_zoom_level, grid_sizes[0], grid_sizes[1], tile_size[0], tile_size[1], res, res))
+                        conn.execute("""
+INSERT OR REPLACE INTO gpkg_tile_matrix (table_name, zoom_level, matrix_width, matrix_height, tile_width, tile_height, pixel_x_size, pixel_y_size) 
+VALUES(?, ?, ?, ?, ?, ?, ?, ?)""", (table_name, actual_zoom_level, grid_sizes[0], grid_sizes[1], tile_size[0], tile_size[1], res, res))
     except Exception as e:
         print(e)

--- a/eventkit_cloud/utils/geopackage.py
+++ b/eventkit_cloud/utils/geopackage.py
@@ -185,6 +185,12 @@ def get_tile_table_names(gpkg):
 
 
 def get_table_gpkg_contents_information(gpkg, table_name):
+    """
+    
+    :param gpkg: Path to geopackage file.
+    :param table_name: A table name to look up in gpkg_contents.
+    :return: A dict with the column names as the keys.
+    """
     with sqlite3.connect(gpkg) as conn:
         result = conn.execute(
             "SELECT table_name, data_type, identifier, description, last_change, min_x, min_y, max_x, max_y, srs_id FROM gpkg_contents WHERE table_name = '{0}';".format(
@@ -205,7 +211,7 @@ def get_table_gpkg_contents_information(gpkg, table_name):
 def get_table_tile_matrix_information(gpkg, table_name):
     with sqlite3.connect(gpkg) as conn:
         result = conn.execute(
-            "SELECT table_name, zoom_level, matrix_width, matrix_height, tile_width, tile_height, pixel_x_size, pixel_y_size FROM gpkg_tile_matrix WHERE table_name = '{0}' ORDER BY zoom_level;;".format(
+            "SELECT table_name, zoom_level, matrix_width, matrix_height, tile_width, tile_height, pixel_x_size, pixel_y_size FROM gpkg_tile_matrix WHERE table_name = '{0}' ORDER BY zoom_level;".format(
                 table_name))
         tile_matrix_information = []
         for table_information in result:

--- a/eventkit_cloud/utils/geopackage.py
+++ b/eventkit_cloud/utils/geopackage.py
@@ -70,7 +70,8 @@ def add_geojson_to_geopackage(geojson=None, gpkg=None, layer_name=None, task_uid
         """
 
     if not geojson or not gpkg:
-        raise Exception("A valid geojson: {0} was not provided\nor a geopackage: {1} was not accessible.".format(geojson, gpkg))
+        raise Exception(
+            "A valid geojson: {0} was not provided\nor a geopackage: {1} was not accessible.".format(geojson, gpkg))
 
     geojson_file = os.path.join(os.path.dirname(gpkg),
                                 "{0}.geojson".format(os.path.splitext(os.path.basename(gpkg))[0]))
@@ -124,7 +125,6 @@ def clip_geopackage(geojson_file=None, gpkg=None, task_uid=None):
         logger.error('{0}'.format(task_process.stderr))
         raise Exception("ogr2ogr process failed with returncode: {0}".format(task_process.exitcode))
     return gpkg
-
 
 
 def is_alnum(data):
@@ -182,6 +182,42 @@ def get_tile_table_names(gpkg):
     with sqlite3.connect(gpkg) as conn:
         result = conn.execute("SELECT table_name FROM gpkg_contents WHERE data_type = 'tiles';")
         return [table for (table,) in result]
+
+
+def get_table_gpkg_contents_information(gpkg, table_name):
+    with sqlite3.connect(gpkg) as conn:
+        result = conn.execute(
+            "SELECT table_name, data_type, identifier, description, last_change, min_x, min_y, max_x, max_y, srs_id FROM gpkg_contents WHERE table_name = '{0}';".format(
+                table_name))
+        table_information = result.fetchone()
+        return {"table_name": table_information[0],
+                "data_type": table_information[1],
+                "identifier": table_information[2],
+                "description": table_information[3],
+                "last_change": table_information[4],
+                "min_x": table_information[5],
+                "min_y": table_information[6],
+                "max_x": table_information[7],
+                "max_y": table_information[8],
+                "srs_id": table_information[9]}
+
+
+def get_table_tile_matrix_information(gpkg, table_name):
+    with sqlite3.connect(gpkg) as conn:
+        result = conn.execute(
+            "SELECT table_name, zoom_level, matrix_width, matrix_height, tile_width, tile_height, pixel_x_size, pixel_y_size FROM gpkg_tile_matrix WHERE table_name = '{0}' ORDER BY zoom_level;;".format(
+                table_name))
+        tile_matrix_information = []
+        for table_information in result:
+            tile_matrix_information += [{"table_name": table_information[0],
+                                         "zoom_level": table_information[1],
+                                         "matrix_width": table_information[2],
+                                         "matrix_height": table_information[3],
+                                         "tile_width": table_information[4],
+                                         "tile_height": table_information[5],
+                                         "pixel_x_size": table_information[6],
+                                         "pixel_y_size": table_information[7]}]
+    return tile_matrix_information
 
 
 def get_zoom_levels_table(gpkg, table):
@@ -268,6 +304,7 @@ def check_zoom_levels(gpkg):
             return False
     return True
 
+
 def get_table_info(gpkg, table):
     """
     Checks the zoom levels for the geopackage returns False if ANY gpkg_tile_matrix sets do no match the zoom levels
@@ -280,6 +317,7 @@ def get_table_info(gpkg, table):
         logger.debug("PRAGMA table_info({0});".format(table))
         return conn.execute("PRAGMA table_info({0});".format(table))
     return False
+
 
 def create_table_from_existing(gpkg, old_table, new_table):
     """


### PR DESCRIPTION
Mapproxy by default creates zoom levels for 0-19 in the geopackage gpkg_tile_matrix.  However in some occasions a user may cache levels >19.  This PR will check the geopackage after it is seeded and add in the missing zoom levels.  

To test, export a raster service with zoom levels greater than 19 (for example OSM Tiles).  And ensure the gpkg_tile_matrix has all of the zoom levels.