### PR TITLE
Changed requirements to use django-audit-logging v0.1.3 & re-enabled in settings.

### DIFF
--- a/eventkit_cloud/settings/prod.py
+++ b/eventkit_cloud/settings/prod.py
@@ -75,8 +75,7 @@ LOGGING_LOG_SQL = DEBUG
 
 INSTALLED_APPS += (
     'django_extensions',
-    #disabled
-    #'audit_logging',
+    'audit_logging',
 )
 
 DATABASES = {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -82,4 +82,4 @@ waitress==1.0.2
 WebOb==1.7.1
 WebTest==2.0.26
 whitenoise==3.3.0
--e git+https://github.com/JivanAmara/django-audit-logging.git@v0.1.2#egg=django-audit-logging
+-e git+https://github.com/JivanAmara/django-audit-logging.git@v0.1.3#egg=django-audit-logging


### PR DESCRIPTION
The changes in this version of django-audit-logging eliminate the errors that have been occurring in integration tests.
